### PR TITLE
:adhesive_bandage: 업데이트 날짜 표시되도록 변경

### DIFF
--- a/src/components/kanban-task/task-view-content.tsx
+++ b/src/components/kanban-task/task-view-content.tsx
@@ -10,7 +10,7 @@ const TaskViewContent = ({ task }: { task: TaskFields }) => {
       </div>
       <div className="space-y-1">
         <span className="font-semibold text-baltic-400">업데이트 날짜</span>
-        <p>{formatKoDate(task.createdAt)}</p>
+        <p>{formatKoDate(task.updatedAt)}</p>
       </div>
     </div>
   );

--- a/src/components/kanban-task/task.tsx
+++ b/src/components/kanban-task/task.tsx
@@ -31,7 +31,7 @@ const Task = ({ taskId, className }: TaskProps) => {
             className="p-4"
           >
             <h4 className="line-clamp-2 text-[15px] font-semibold">{task.title}</h4>
-            <small className="text-xs text-baltic-400">{formatKoDate(task.createdAt)}</small>
+            <small className="text-xs text-baltic-400">{formatKoDate(task.updatedAt)}</small>
           </motion.div>
         </TaskEditViewDialog>
       )}


### PR DESCRIPTION
### **User description**
closes #38


___

### **PR Type**
Bug fix


___

### **Description**
- Fix task update date display issue.

- Change date field from `createdAt` to `updatedAt`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>task-view-content.tsx</strong><dd><code>Display correct task update date in task view</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/kanban-task/task-view-content.tsx

<li>Changed date display from <code>createdAt</code> to <code>updatedAt</code>.<br> <li> Ensured task update date is correctly shown.


</details>


  </td>
  <td><a href="https://github.com/romantech/simple-kanban/pull/41/files#diff-9053f2147c4cd4a3a37da9481206842731c7b0e786b908ac5142c885b5592de2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>task.tsx</strong><dd><code>Correct task update date in task component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/kanban-task/task.tsx

<li>Updated date field from <code>createdAt</code> to <code>updatedAt</code>.<br> <li> Corrected task date display in task component.


</details>


  </td>
  <td><a href="https://github.com/romantech/simple-kanban/pull/41/files#diff-c20596b4c07a5890b7b1534181173d412a73afd667453a94845515cfd3d9c522">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>