### PR TITLE
:children_crossing: 보드 삭제 후 타이틀 미반영되는 문제 해결

### DIFF
--- a/src/components/kanban-header/header-dropdown.tsx
+++ b/src/components/kanban-header/header-dropdown.tsx
@@ -30,9 +30,9 @@ const HeaderDropdown = () => {
   const shouldDisableDelete = boardCount <= 1;
 
   const onConfirmDelete = () => {
-    deleteBoard(currentBoardId);
+    const { id, title } = deleteBoard(currentBoardId);
     setOpenMenu(false);
-    router.replace(useKanbanStore.getState().currentBoardId);
+    router.replace(`${id}?title=${title}`);
   };
 
   return (

--- a/src/store/kanban-store.ts
+++ b/src/store/kanban-store.ts
@@ -15,13 +15,13 @@ export type KanbanState = BoardSlice & ColumnSlice & TaskSlice;
 export type KanbanStateUnion = BoardSlice | ColumnSlice | TaskSlice;
 
 export type KanbanSliceCreator<T extends KanbanStateUnion> = StateCreator<
-  BoardSlice & ColumnSlice & TaskSlice, // Kanban 보드의 전체 상태
+  KanbanState, // Kanban 보드의 전체 상태
   [
-    ['zustand/subscribeWithSelector', never], // Zustand 미들웨어
+    ['zustand/subscribeWithSelector', never],
     ['zustand/immer', never],
     ['zustand/persist', unknown],
     ['zustand/devtools', never],
-  ],
+  ], // Zustand 미들웨어
   [],
   T // 개별 Slice 상태
 >;

--- a/src/store/slices/board-slice.ts
+++ b/src/store/slices/board-slice.ts
@@ -10,7 +10,7 @@ export interface BoardSlice {
   addBoard: Void<[BoardFields, boolean]>;
   editBoard: Void<[BoardId, TitleField]>;
   setCurrentBoard: Void<[BoardId]>;
-  deleteBoard: Void<[BoardId]>;
+  deleteBoard: (boardId: BoardId) => BoardFields;
   getBoardCount: () => number;
 }
 
@@ -58,6 +58,9 @@ export const createBoardSlice: BoardSliceCreator = (set, get) => ({
 
       delete state.boards[boardId];
     });
+    // 상태 변경 후 실행됨
+    const { boards, currentBoardId } = get();
+    return boards[currentBoardId];
   },
   setCurrentBoard: (boardId) => {
     set((state) => {


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix issue with title not updating after board deletion.

- Enhance `deleteBoard` to return board details.

- Update router replacement logic with board title.

- Improve type annotations in `kanban-store`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>header-dropdown.tsx</strong><dd><code>Update board deletion logic in header dropdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/kanban-header/header-dropdown.tsx

<li>Update <code>deleteBoard</code> to return board details.<br> <li> Modify router replacement to include board title.


</details>


  </td>
  <td><a href="https://github.com/romantech/simple-kanban/pull/42/files#diff-fde9dc49253c0947f3a53e25bc5778273762932755619c5ed81ac44880dfdf1d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kanban-store.ts</strong><dd><code>Enhance type annotations in kanban-store</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/store/kanban-store.ts

- Improve type annotations for Kanban state.


</details>


  </td>
  <td><a href="https://github.com/romantech/simple-kanban/pull/42/files#diff-24b78137323f91e68e17159d0ce18f07561e7b1b1ccb8406c3f5f386289cc784">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>board-slice.ts</strong><dd><code>Enhance deleteBoard to return board details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/store/slices/board-slice.ts

<li>Change <code>deleteBoard</code> to return board fields.<br> <li> Add logic to return current board details post-deletion.


</details>


  </td>
  <td><a href="https://github.com/romantech/simple-kanban/pull/42/files#diff-b620788ed90550b3910e3548e2d978bf4ac06e143cfd942f7626dd83c71c4657">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>